### PR TITLE
Support .env filename as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ is required in the same folder as the `.env.example` file.
     # yarn add @zentered/envsync
 ```
 
-Two things are required to use `EnvSync`:
+#### Two things are required to use `EnvSync`:
 
 1. An `.env.example` file (use `envsync//[variable]` to indicate a variable that
    should be fetched from Secrets Manager). The first variable should be
@@ -68,6 +68,11 @@ Two things are required to use `EnvSync`:
   }
 }
 ```
+
+#### Optional: Specifying the `.env` file:
+
+- If you have multiple `.env` files, you can provide the filename as an argument. The `.env` example file must end in `.example`
+- Usage: `npx envsync .env.development.example` will create `.env.development`
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ import fs from 'fs/promises'
 import { readExample } from './lib/readExample.js'
 import { joinEnv } from './lib/joinEnv.js'
 
-const exampleFile = await fs.readFile('.env.example', 'utf8')
+const args = process.argv.slice(2);
+const filePath = args[0] || '.env.example'
+
+const exampleFile = await fs.readFile(filePath, 'utf8')
 const env = await readExample(exampleFile)
-await fs.writeFile('.env', joinEnv(env))
+const output = filePath.replace(".example", "")
+await fs.writeFile(output, joinEnv(env))


### PR DESCRIPTION
The use case here is someone has multiple `.env` files per environment, e.g. `.env.local`, `.env.sandbox`, `.env.prod`.

So they can run `envsync .env.local.example` to output `.env.local`.

If no parameter is provided, it uses the default `.env.example` that's currently expected.