### PR TITLE
fix: parsing issues

### DIFF
--- a/lib/readExample.js
+++ b/lib/readExample.js
@@ -12,7 +12,7 @@ export async function readExample(exampleFile) {
   const output = []
   exampleFile
     .split('\n')
-    .map((line) => line.split('='))
+    .map((line) => line.split(/=(.*)/s))
     .map(([key, value]) => {
       key = key.replace(/\s/g, '')
       value = value?.replace(/\s/g, '')

--- a/test/fetchVariable.test.js
+++ b/test/fetchVariable.test.js
@@ -5,18 +5,17 @@ import esmock from 'esmock'
 test('fetchVariable() returns value from GCP', async () => {
   const { fetchVariable } = await esmock('../lib/fetchVariable.js', {
     '@google-cloud/secret-manager': {
-      SecretManagerServiceClient: () =>
-        class {
-          async accessSecretVersion(name) {
-            return Promise.resolve([
-              {
-                payload: {
-                  data: Buffer.from(name.name)
-                }
+      SecretManagerServiceClient: class {
+        async accessSecretVersion(name) {
+          return Promise.resolve([
+            {
+              payload: {
+                data: Buffer.from(name.name)
               }
-            ])
-          }
+            }
+          ])
         }
+      }
     }
   })
   const [key, value] = await fetchVariable(
@@ -31,18 +30,17 @@ test('fetchVariable() returns value from GCP', async () => {
 test('fetchVariable() returns version from GCP', async () => {
   const { fetchVariable } = await esmock('../lib/fetchVariable.js', {
     '@google-cloud/secret-manager': {
-      SecretManagerServiceClient: () =>
-        class {
-          async accessSecretVersion(name) {
-            return Promise.resolve([
-              {
-                payload: {
-                  data: Buffer.from(name.name)
-                }
+      SecretManagerServiceClient: class {
+        async accessSecretVersion(name) {
+          return Promise.resolve([
+            {
+              payload: {
+                data: Buffer.from(name.name)
               }
-            ])
-          }
+            }
+          ])
         }
+      }
     }
   })
   const [key, value] = await fetchVariable(

--- a/test/readExample.test.js
+++ b/test/readExample.test.js
@@ -24,5 +24,5 @@ test('joinEnv() returns value from GCP', async () => {
     ['AUTH0_CLIENT_SECRET', 'envsync//testkey/latest'],
     ['']
   ]
-  assert.same(actual, expected)
+  assert.deepStrictEqual(actual, expected)
 })

--- a/test/readExample.test.js
+++ b/test/readExample.test.js
@@ -15,13 +15,16 @@ test('joinEnv() returns value from GCP', async () => {
   NODE_ENV = development
   
   AUTH0_CLIENT_SECRET=envsync//testkey/latest
+  DATABASE_URL=postgresql://hello:world@localhost:5432/postgres?schema=example
   `
+
   const actual = await readExample(file)
   const expected = [
     ['GCP_PROJECT', 'quillcy'],
     ['NODE_ENV', 'development'],
     [''],
     ['AUTH0_CLIENT_SECRET', 'envsync//testkey/latest'],
+    ['DATABASE_URL', 'postgresql://hello:world@localhost:5432/postgres?schema=example'],
     ['']
   ]
   assert.deepStrictEqual(actual, expected)


### PR DESCRIPTION
This PR fixes an issue that would occur when parsing the `env.example` variables causing information to go missing in the resulting `.env` file. 

Envsync would parse the following example environment variable:
`postgresql://hello:world@localhost:5432/postgres?schema=example`
and output it as:
`postgresql://hello:world@localhost:5432/postgres?schema`

In the parsing step, we would lose the `=example` data.
That's because the key value pairs would be split using `split('=')` causing them to split on _all_ instances of `=`. 
We only want to the lines to be split on the _first_ occurrence of the `=`.

The pr contains:
- A fix to solve the parsing issue
- Fixes to failing tests
- Adds a check to the test to verify splitting works correctly now
